### PR TITLE
added push unstable image

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 COMPOSE_PROJECT_NAME=sciencebeam-trainer-grobid
 GROBID_TAG=0.5.4
 IMAGE_TAG=0.5.4-develop
+REVISION=develop

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 COMPOSE_PROJECT_NAME=sciencebeam-trainer-grobid
 GROBID_TAG=0.5.4
-IMAGE_TAG=develop
+IMAGE_TAG=0.5.4-develop

--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 COMPOSE_PROJECT_NAME=sciencebeam-trainer-grobid
 GROBID_TAG=0.5.4
-IMAGE_TAG=0.5.4-develop
 REVISION=develop
+# $GROBID_TAG-$REVISION
+IMAGE_TAG=0.5.4-develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,5 @@ COPY scripts /opt/scripts
 ENV PATH /opt/scripts:$PATH
 
 ENV JAVA_OPTS=-Xmx1G
+
+LABEL org.elifesciences.dependencies.grobid="${grobid_tag}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ COPY --from=builder /opt/grobid-source/grobid-trainer/resources /opt/grobid-sour
 COPY scripts /opt/scripts
 ENV PATH /opt/scripts:$PATH
 
-ENV JAVA_OPTS -Xmx1G
+ENV JAVA_OPTS=-Xmx1G

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,5 @@ ARG grobid_tag
 ENV GROBID_VERSION=${grobid_tag}
 LABEL org.elifesciences.dependencies.grobid="${grobid_tag}"
 
-ARG image_tag
-LABEL org.opencontainers.image.revision="${image_tag}"
+ARG revision
+LABEL org.opencontainers.image.revision="${revision}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,6 @@ RUN mkdir -p /usr/local/gcloud \
 
 ENV PATH /usr/local/gcloud/google-cloud-sdk/bin:$PATH
 
-ARG grobid_tag
-ENV GROBID_VERSION=${grobid_tag}
-
 WORKDIR /opt/grobid
 COPY --from=builder /opt/grobid/* ./
 COPY --from=builder /opt/grobid-source/grobid-home /opt/grobid-source/grobid-home
@@ -31,4 +28,9 @@ ENV PATH /opt/scripts:$PATH
 
 ENV JAVA_OPTS=-Xmx1G
 
+ARG grobid_tag
+ENV GROBID_VERSION=${grobid_tag}
 LABEL org.elifesciences.dependencies.grobid="${grobid_tag}"
+
+ARG image_tag
+LABEL org.opencontainers.image.revision="${image_tag}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,4 @@ LABEL org.elifesciences.dependencies.grobid="${grobid_tag}"
 
 ARG revision
 LABEL org.opencontainers.image.revision="${revision}"
+LABEL org.opencontainers.image.source=https://github.com/elifesciences/sciencebeam-trainer-grobid

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ elifePipeline {
             checkout scm
             commit = elifeGitRevision()
             fullImageTag = sh(
-                script: "docker-compose config | grep -P -o '(?<=\simage: elifesciences/sciencebeam-trainer-grobid-builder:)\S+'"
+                script: "docker-compose config | grep -P -o '(?<=\\simage: elifesciences/sciencebeam-trainer-grobid-builder:)\\S+'"
             ).trim()
             echo "Full image tag: ${fullImageTag}"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ elifePipeline {
         }
 
         stage 'Check GROBID label', {
+            echo "Checking GROBID label..."
             def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', fullImageTag)
             echo "Reading GROBID label of image '${image}'..."
             def actualGrobidTag = sh(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ elifePipeline {
                 script: "docker-read-label ${image} org.elifesciences.dependencies.grobid",
                 returnStdout: true
             )
+            echo "GROBID label: ${actualGrobidTag} (expected: ${grobidTag})"
             assert actualGrobidTag == grobidTag
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ elifePipeline {
             checkout scm
             commit = elifeGitRevision()
             grobidTag = sh(
-                script: 'bash -c "source .env && echo \$GROBID_TAG"',
+                script: 'bash -c "source .env && echo \\$GROBID_TAG"',
                 returnStdout: true
             ).trim()
             echo "GROBID_TAG: ${grobidTag}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,15 @@ elifePipeline {
             }
         }
 
+        stage 'Check GROBID label', {
+            def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', fullImageTag)
+            def actualGrobidTag = sh(
+                script: "docker-read-label ${image} org.elifesciences.dependencies.grobid",
+                returnStdout: true
+            )
+            assert actualGrobidTag == grobidTag
+        }
+
         elifeMainlineOnly {
             stage 'Merge to master', {
                 elifeGitMoveToBranch commit, 'master'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,9 +28,9 @@ elifePipeline {
         stage 'Check GROBID label', {
             echo "Checking GROBID label..."
             def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', fullImageTag)
-            echo "Reading GROBID label of image: ${image}"
+            echo "Reading GROBID label of image: ${image.toString()}"
             def actualGrobidTag = sh(
-                script: "./ci/docker-read-local-label.sh ${image} org.elifesciences.dependencies.grobid",
+                script: "./ci/docker-read-local-label.sh ${image.toString()} org.elifesciences.dependencies.grobid",
                 returnStdout: true
             ).trim()
             echo "GROBID label: ${actualGrobidTag} (expected: ${grobidTag})"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,13 @@ elifePipeline {
             stage 'Merge to master', {
                 elifeGitMoveToBranch commit, 'master'
             }
+
+            stage 'Push unstable image', {
+                def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', commit)
+                def unstable_image = image.addSuffixAndTag('_unstable', commit)
+                unstable_image.tag('latest').push()
+                unstable_image.push()
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ elifePipeline {
             stage 'Push unstable image', {
                 def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', fullImageTag)
                 def unstable_image = image.addSuffixAndTag('_unstable', fullImageTag)
-                unstable_image.tag("${grobidTag}-latest").push()
+                unstable_image.tag("${grobidTag}").push()
                 unstable_image.push()
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ elifePipeline {
         stage 'Check GROBID label', {
             def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', fullImageTag)
             def actualGrobidTag = sh(
-                script: "docker-read-label ${image} org.elifesciences.dependencies.grobid",
+                script: "./ci/docker-read-local-label.sh ${image} org.elifesciences.dependencies.grobid",
                 returnStdout: true
             ).trim()
             echo "GROBID label: ${actualGrobidTag} (expected: ${grobidTag})"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,8 @@ elifePipeline {
             checkout scm
             commit = elifeGitRevision()
             fullImageTag = sh(
-                script: "docker-compose config | grep -P -o '(?<=\\simage: elifesciences/sciencebeam-trainer-grobid-builder:)\\S+'"
+                script: "docker-compose config | grep -P -o '(?<=\\simage: elifesciences/sciencebeam-trainer-grobid-builder:)\\S+'",
+                returnStdout: true
             ).trim()
             echo "Full image tag: ${fullImageTag}"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,10 @@ elifePipeline {
         stage 'Checkout', {
             checkout scm
             commit = elifeGitRevision()
-            grobidTag = sh(script: 'bash -c "source .env && echo $GROBID_TAG"', returnStdout: true)
+            grobidTag = sh(
+                script: 'bash -c "source .env && echo $GROBID_TAG"',
+                returnStdout: true
+            ).trim()
             echo "GROBID_TAG: ${grobidTag}"
             fullImageTag = "${grobidTag}-${commit}"
             echo "Full image tag: ${fullImageTag}"
@@ -26,7 +29,7 @@ elifePipeline {
             def actualGrobidTag = sh(
                 script: "docker-read-label ${image} org.elifesciences.dependencies.grobid",
                 returnStdout: true
-            )
+            ).trim()
             echo "GROBID label: ${actualGrobidTag} (expected: ${grobidTag})"
             assert actualGrobidTag == grobidTag
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,15 @@
 elifePipeline {
     node('containers-jenkins-plugin') {
         def commit
+        def fullImageTag
 
         stage 'Checkout', {
             checkout scm
             commit = elifeGitRevision()
+            fullImageTag = sh(
+                script: "docker-compose config | grep -P -o '(?<=\simage: elifesciences/sciencebeam-trainer-grobid-builder:)\S+'"
+            ).trim()
+            echo "Full image tag: ${fullImageTag}"
         }
 
         stage 'Build and run tests', {
@@ -21,8 +26,8 @@ elifePipeline {
             }
 
             stage 'Push unstable image', {
-                def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', commit)
-                def unstable_image = image.addSuffixAndTag('_unstable', commit)
+                def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', fullImageTag)
+                def unstable_image = image.addSuffixAndTag('_unstable', fullImageTag)
                 unstable_image.tag('latest').push()
                 unstable_image.push()
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,14 @@
 elifePipeline {
     node('containers-jenkins-plugin') {
         def commit
+        def grobidTag
         def fullImageTag
 
         stage 'Checkout', {
             checkout scm
             commit = elifeGitRevision()
+            grobidTag = sh('source .env && echo $GROBID_TAG', returnStdout: true)
+            echo "GROBID_TAG: ${grobidTag}"
             fullImageTag = sh(
                 script: "docker-compose config | grep -P -o '(?<=\\simage: elifesciences/sciencebeam-trainer-grobid-builder:)\\S+'",
                 returnStdout: true
@@ -29,7 +32,7 @@ elifePipeline {
             stage 'Push unstable image', {
                 def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', fullImageTag)
                 def unstable_image = image.addSuffixAndTag('_unstable', fullImageTag)
-                unstable_image.tag('latest').push()
+                unstable_image.tag("${grobidTag}-latest").push()
                 unstable_image.push()
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ elifePipeline {
         stage 'Check GROBID label', {
             echo "Checking GROBID label..."
             def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', fullImageTag)
-            echo "Reading GROBID label of image '${image}'..."
+            echo "Reading GROBID label of image: ${image}"
             def actualGrobidTag = sh(
                 script: "./ci/docker-read-local-label.sh ${image} org.elifesciences.dependencies.grobid",
                 returnStdout: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,9 +19,9 @@ elifePipeline {
 
         stage 'Build and run tests', {
             try {
-                sh "IMAGE_TAG=${fullImageTag} make ci-build-and-test"
+                sh "IMAGE_TAG=${fullImageTag} REVISION=${commit} make ci-build-and-test"
             } finally {
-                sh "IMAGE_TAG=${fullImageTag} make ci-clean"
+                sh "IMAGE_TAG=${fullImageTag} REVISION=${commit} make ci-clean"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ elifePipeline {
 
         stage 'Check GROBID label', {
             def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', fullImageTag)
+            echo "Reading GROBID label of image '${image}'..."
             def actualGrobidTag = sh(
                 script: "./ci/docker-read-local-label.sh ${image} org.elifesciences.dependencies.grobid",
                 returnStdout: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ elifePipeline {
         stage 'Checkout', {
             checkout scm
             commit = elifeGitRevision()
-            grobidTag = sh(script: 'source .env && echo $GROBID_TAG', returnStdout: true)
+            grobidTag = sh(script: 'bash -c "source .env && echo $GROBID_TAG"', returnStdout: true)
             echo "GROBID_TAG: ${grobidTag}"
             fullImageTag = sh(
                 script: "docker-compose config | grep -P -o '(?<=\\simage: elifesciences/sciencebeam-trainer-grobid-builder:)\\S+'",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,9 +19,9 @@ elifePipeline {
 
         stage 'Build and run tests', {
             try {
-                sh "make ci-build-and-test"
+                sh "IMAGE_TAG=${fullImageTag} make ci-build-and-test"
             } finally {
-                sh "make ci-clean"
+                sh "IMAGE_TAG=${fullImageTag} make ci-clean"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,7 @@ elifePipeline {
             commit = elifeGitRevision()
             grobidTag = sh(script: 'bash -c "source .env && echo $GROBID_TAG"', returnStdout: true)
             echo "GROBID_TAG: ${grobidTag}"
-            fullImageTag = sh(
-                script: "docker-compose config | grep -P -o '(?<=\\simage: elifesciences/sciencebeam-trainer-grobid-builder:)\\S+'",
-                returnStdout: true
-            ).trim()
+            fullImageTag = "${grobidTag}-${commit}"
             echo "Full image tag: ${fullImageTag}"
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ elifePipeline {
             stage 'Push unstable image', {
                 def image = DockerImage.elifesciences(this, 'sciencebeam-trainer-grobid', fullImageTag)
                 def unstable_image = image.addSuffixAndTag('_unstable', fullImageTag)
-                unstable_image.tag("${grobidTag}").push()
+                unstable_image.tag(grobidTag).push()
                 unstable_image.push()
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,10 +8,11 @@ elifePipeline {
             checkout scm
             commit = elifeGitRevision()
             grobidTag = sh(
-                script: 'bash -c "source .env && echo $GROBID_TAG"',
+                script: 'bash -c "source .env && echo \$GROBID_TAG"',
                 returnStdout: true
             ).trim()
             echo "GROBID_TAG: ${grobidTag}"
+            assert grobidTag != ''
             fullImageTag = "${grobidTag}-${commit}"
             echo "Full image tag: ${fullImageTag}"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ elifePipeline {
         stage 'Checkout', {
             checkout scm
             commit = elifeGitRevision()
-            grobidTag = sh('source .env && echo $GROBID_TAG', returnStdout: true)
+            grobidTag = sh(script: 'source .env && echo $GROBID_TAG', returnStdout: true)
             echo "GROBID_TAG: ${grobidTag}"
             fullImageTag = sh(
                 script: "docker-compose config | grep -P -o '(?<=\\simage: elifesciences/sciencebeam-trainer-grobid-builder:)\\S+'",

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ shell: build
 
 
 ci-build-and-test:
-	make DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" build
+	make DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" example-data-processing-end-to-end
 
 
 ci-clean:

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ shell: build
 
 
 ci-build-and-test:
-	make DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" example-data-processing-end-to-end
+	make DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" build
 
 
 ci-clean:

--- a/ci/docker-read-local-label.sh
+++ b/ci/docker-read-local-label.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 IMAGE LABEL"
+    echo "Example: $0 elifesciences/annotations_cli org.elifesciences.dependencies.api-dummy"
+    exit 1
+fi
+
+image="${1}"
+label="${2}"
+docker inspect "${image}" | jq -r ".[0].Config.Labels[\"${label}\"]"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,15 +7,15 @@ services:
       dockerfile: Dockerfile.builder
       args:
         grobid_tag: ${GROBID_TAG}
-    image: elifesciences/sciencebeam-trainer-grobid-builder:${GROBID_TAG}-${IMAGE_TAG}
+    image: elifesciences/sciencebeam-trainer-grobid-builder:${IMAGE_TAG}
   sciencebeam-trainer-grobid:
     build:
       context: .
       dockerfile: Dockerfile
       args:
-        builder_image: elifesciences/sciencebeam-trainer-grobid-builder:${GROBID_TAG}-${IMAGE_TAG}
+        builder_image: elifesciences/sciencebeam-trainer-grobid-builder:${IMAGE_TAG}
         grobid_tag: ${GROBID_TAG}
-    image: elifesciences/sciencebeam-trainer-grobid:${GROBID_TAG}-${IMAGE_TAG}
+    image: elifesciences/sciencebeam-trainer-grobid:${IMAGE_TAG}
     depends_on:
       - grobid-builder
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       args:
         builder_image: elifesciences/sciencebeam-trainer-grobid-builder:${IMAGE_TAG}
         grobid_tag: ${GROBID_TAG}
-        image_tag: ${IMAGE_TAG}
+        revision: ${REVISION}
     image: elifesciences/sciencebeam-trainer-grobid:${IMAGE_TAG}
     depends_on:
       - grobid-builder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       args:
         builder_image: elifesciences/sciencebeam-trainer-grobid-builder:${IMAGE_TAG}
         grobid_tag: ${GROBID_TAG}
+        image_tag: ${IMAGE_TAG}
     image: elifesciences/sciencebeam-trainer-grobid:${IMAGE_TAG}
     depends_on:
       - grobid-builder


### PR DESCRIPTION
Pushing the image.

Slightly more complex because it consists of two versions - one is the parameterised GROBID_TAG (which we could also build multiple images of), the other is the commit / release version of the wrapper code.