### PR TITLE
pin java version to 8u212

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM openjdk:8u212-jre-slim
 
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
-    wget unzip libxml2 rename gcc g++ \
+    wget curl unzip libxml2 rename gcc g++ \
     python3-minimal python3-venv libpython3-stdlib python3-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG builder_image
 FROM ${builder_image} AS builder
 
-FROM openjdk:8-jre-stretch
+FROM openjdk:8u212-jre-slim
 
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-stretch AS builder
+FROM openjdk:8u212-jdk-stretch AS builder
 
 ARG grobid_tag
 RUN wget --output-document=/tmp/grobid.zip --quiet --show-progress --progress=bar:force:noscroll \


### PR DESCRIPTION
Use the same version as GROBID itself. This should also fix an issue with using an old version of Python (3.5.3)