### PR TITLE
added support for renamed headers/corpus/raw dir

### DIFF
--- a/scripts/copy-raw-training-data-to-file-structure.sh
+++ b/scripts/copy-raw-training-data-to-file-structure.sh
@@ -75,11 +75,21 @@ copy_segmentation_files() {
 }
 
 copy_header_files() {
-    copy_and_rename_tei_and_raw_training_files \
-        "$DATASET_DIR/header/corpus/tei-raw" \
-        "*.header.tei.xml" \
-        "$DATASET_DIR/header/corpus/headers" \
-        "*.header"
+    if [ -d "/opt/grobid-source/grobid-trainer/resources/dataset/header/corpus/headers" ]; then
+        # prior GROBID 0.6.1
+        copy_and_rename_tei_and_raw_training_files \
+            "$DATASET_DIR/header/corpus/tei-raw" \
+            "*.header.tei.xml" \
+            "$DATASET_DIR/header/corpus/headers" \
+            "*.header"
+    else
+        # from GROBID 0.6.1
+        copy_and_rename_tei_and_raw_training_files \
+            "$DATASET_DIR/header/corpus/tei-raw" \
+            "*.header.tei.xml" \
+            "$DATASET_DIR/header/corpus/raw" \
+            "*.header"
+    fi
 }
 
 copy_fulltext_files() {

--- a/scripts/train-model.sh
+++ b/scripts/train-model.sh
@@ -66,10 +66,19 @@ if [ "${MODEL_NAME}" == "segmentation" ]; then
         "segmentation/corpus/tei"
     )
 elif [ "${MODEL_NAME}" == "header" ]; then
-    sub_dirs=(
-        "header/corpus/headers"
-        "header/corpus/tei"
-    )
+    if [ -d "/opt/grobid-source/grobid-trainer/resources/dataset/header/corpus/headers" ]; then
+        # prior GROBID 0.6.1
+        sub_dirs=(
+            "header/corpus/headers"
+            "header/corpus/tei"
+        )
+    else
+        # from GROBID 0.6.1
+        sub_dirs=(
+            "header/corpus/raw"
+            "header/corpus/tei"
+        )
+    fi
 elif [ "${MODEL_NAME}" == "fulltext" ]; then
     sub_dirs=(
         "fulltext/corpus/raw"

--- a/scripts/upload-dataset.sh
+++ b/scripts/upload-dataset.sh
@@ -41,6 +41,7 @@ sub_dirs=(
     "segmentation/corpus/tei"
     "segmentation/corpus/tei-raw"
     "segmentation/corpus/tei-auto"
+    "header/corpus/raw"
     "header/corpus/headers"
     "header/corpus/tei"
     "header/corpus/tei-raw"


### PR DESCRIPTION
the directory `headers/corpus/headers` was renamed to `headers/corpus/raw` since GROBID 0.6.1.