### PR TITLE
added pip dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ venv-create:
 
 
 dev-install:
+	$(PIP) install -r requirements.build.txt
 	$(PIP) install -r requirements.txt
 	$(PIP) install -r requirements.dev.txt
 	$(PIP) install -e . --no-deps

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,2 +1,3 @@
+pip==20.2.3
 setuptools==50.3.0
 wheel==0.35.1


### PR DESCRIPTION
this should make dependencies like `grpc` faster to install (by allowing it to use binary wheels which require a newer version of `pip`)